### PR TITLE
Create winxp-in-the.web

### DIFF
--- a/Websites/winxp-in-the.web
+++ b/Websites/winxp-in-the.web
@@ -1,0 +1,5 @@
+url = "https://lrusso.github.io/VirtualXP/VirtualXP.htm"
+current_tab_name = "Windows XP"
+
+mainloop:
+iframe url "iframe1" 0 -20 window."width" window."height" - 40


### PR DESCRIPTION
A Windows XP emulator in the web. It doesn't have a web browser (go figure), has keyboard input disabled for some reason that I can't fix and its very slow at loading.